### PR TITLE
stagger_output needs Pry::Pager to be loaded in the parent scope

### DIFF
--- a/lib/pry-remote-em/client.rb
+++ b/lib/pry-remote-em/client.rb
@@ -7,6 +7,7 @@ rescue LoadError => e
 end
 require "pry-remote-em/client/generic"
 require 'pry/helpers/base_helpers'
+require 'pry/pager'
 require "readline"
 require 'highline'
 


### PR DESCRIPTION
in at least Pry 0.9.11.4, `Pry::Helpers::BaseHelpers#receive_raw` assumes that you have `Pry::Pager` loaded in the including context and does not require it explicitly, so you get this:

```
[pry-remote-em] unable to load keyboard depenencies (termios); interactive shell commands disabled
[pry-remote-em] client connected to pryem://127.0.0.1:6463/
[pry-remote-em] remote is PryRemoteEm 0.7.3 pryem
[pry-remote-em] session terminated
/Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/pry-0.9.11.4/lib/pry/helpers/base_helpers.rb:119:in `stagger_output': uninitialized constant Pry::Pager (NameError)
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/pry-remote-em-0.7.3/lib/pry-remote-em/client.rb:211:in `receive_raw'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/pry-remote-em-0.7.3/lib/pry-remote-em/proto.rb:59:in `receive_json'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/pry-remote-em-0.7.3/lib/pry-remote-em/proto.rb:47:in `receive_data'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/eventmachine-1.0.0/lib/eventmachine.rb:187:in `run_machine'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/eventmachine-1.0.0/lib/eventmachine.rb:187:in `run'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/gems/pry-remote-em-0.7.3/bin/pry-remote-em:64:in `<top (required)>'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/bin/pry-remote-em:23:in `load'
        from /Users/pcmantz/.rvm/gems/ruby-1.9.3-p194@vamp-api/bin/pry-remote-em:23:in `<main>'
```

All this patch does is load `Pry::Pager` so that the macro is happy.
