### PR TITLE
require 'pry', not its parts

### DIFF
--- a/lib/pry-remote-em/client.rb
+++ b/lib/pry-remote-em/client.rb
@@ -6,8 +6,7 @@ rescue LoadError => e
   warn "[pry-remote-em] unable to load keyboard depenencies (termios); interactive shell commands disabled"
 end
 require "pry-remote-em/client/generic"
-require 'pry/helpers/base_helpers'
-require 'pry/pager'
+require 'pry'
 require "readline"
 require 'highline'
 


### PR DESCRIPTION
On the latest pry, this breaks because not everything is loaded.

We could fix it by adding more parts, explicitly (and in fact the Github
version of pry will also fix this), but it's more robust to just get the
root.
