### PR TITLE
Support Ctrl-D to terminate session

### DIFF
--- a/lib/pry-remote-em/client.rb
+++ b/lib/pry-remote-em/client.rb
@@ -247,7 +247,10 @@ module PryRemoteEm
       if @negotiated && !@unbound
         op       = proc { Readline.readline(prompt, !prompt.nil?) }
         callback = proc do |l|
-          if '!!' == l[0..1]
+          if l.nil? # user pressed Ctrl-D
+            Kernel.puts
+            send_raw("exit")
+          elsif '!!' == l[0..1]
             send_msg_bcast(l[2..-1])
           elsif '!' == l[0]
             send_msg(l[1..-1])


### PR DESCRIPTION
pry-remote-em currently blows up if you press Ctrl-D, with:

```
/Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/pry-remote-em-0.7.5/lib/pry-remote-em/client.rb:250:in `block in readline': undefined method `[]' for nil:NilClass (NoMethodError)
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:951:in `call'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:951:in `run_deferred_callbacks'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run_machine'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/eventmachine-1.0.3/lib/eventmachine.rb:187:in `run'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/pry-remote-em-0.7.5/bin/pry-remote-em:64:in `<top (required)>'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/bin/pry-remote-em:23:in `load'
    from /Users/nbudin/.rbenv/versions/2.0.0-p195/bin/pry-remote-em:23:in `<main>'
```

This patch simply checks if the line passed to the callback is nil, and if so, assumes the user pressed Ctrl-D to end the session.
