### PR TITLE
Client::Generic ignores opts

### DIFF
--- a/lib/pry-remote-em/client/generic.rb
+++ b/lib/pry-remote-em/client/generic.rb
@@ -6,7 +6,7 @@ module PryRemoteEm
       include EM::Deferrable
       include Proto
 
-      def initialize(opt = {})
+      def initialize(opts = {})
         @opts   = opts
       end
 


### PR DESCRIPTION
PryRemoteEm::Client::Generic ignores the options passed to the `initialize` method due to a typo in the parameter name (`opt` instead of `opts`)

This pull request fixes the problem
