### PR TITLE
A lot of bugfixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 
 0.7.3
 - Broker listens at 6462 everything else starts at 6463
+- cli assumes port 6462 when not specified
 
 0.7.2
 - Broker.run yields to a block when broker connection has been established
@@ -28,7 +29,7 @@
 - adds PryRemoteEm.servers and PryRemoteEm.stop_server
 - broker can proxy requests to local or remote servers that have registered with it
 - closes #11 all servers will attempt to register with a broker; client will retrieve list of servers from the broker and present a menu to the user by default
-- when specifying a specific port to listen on the option :port_fail can be set to :auto; if binding fails attempt to bind on the next port 
+- when specifying a specific port to listen on the option :port_fail can be set to :auto; if binding fails attempt to bind on the next port
 - server.run returns a url (String) with the scheme, host and port of the listening server
 - json specific parts of wire protocol are abstracted away from client and server
 - json proto is a bit more robust: delimeter can be a part of data and CRC is performed

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ pry-remote-em  pryem://127.0.0.1:6466/
 
 When more than one server is running on a given host and each server is
 started with :auto it can be time consuming to manually figure out which
-port each server is running on. The Broker which listens on port 6461
+port each server is running on. The Broker which listens on port 6462
 keeps track of which server is running on which port.
 
 By default the pry-remote-em cli utility will connect to the broker and
@@ -152,7 +152,7 @@ through the broker to the selected server.
 ```shell
 
 $ bin/pry-remote-em
-[pry-remote-em] client connected to pryem://127.0.0.1:6461/
+[pry-remote-em] client connected to pryem://127.0.0.1:6462/
 [pry-remote-em] remote is PryRemoteEm 0.7.0 pryem
 -----------------------------------------------------------------------------
 | id  |  name                              |  url                           |
@@ -176,7 +176,7 @@ connect to: 3
 [1] pry(#<#<Class:0x007f924b9bbee8>>)>
 ```
 
-By default the Broker will listen on 127.0.0.1:6461. To change the ip
+By default the Broker will listen on 127.0.0.1:6462. To change the ip
 address that the Broker binds to specify it in a PRYEMBROKER environment
 variable, or in :broker_host option passed to #remote_pry_em.
 
@@ -184,7 +184,7 @@ variable, or in :broker_host option passed to #remote_pry_em.
 
 $ PRYEMBROKER=0.0.0.0 be ./test/service.rb
 I, [2012-07-13T21:10:00.936993 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:6462/
-I, [2012-07-13T21:10:00.937132 #88528]  INFO -- : [pry-remote-em broker] listening on pryem://0.0.0.0:6461
+I, [2012-07-13T21:10:00.937132 #88528]  INFO -- : [pry-remote-em broker] listening on pryem://0.0.0.0:6462
 I, [2012-07-13T21:10:00.937264 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:1337/
 I, [2012-07-13T21:10:00.937533 #88528]  INFO -- : [pry-remote-em] listening for connections on pryems://0.0.0.0:6463/
 I, [2012-07-13T21:10:00.937804 #88528]  INFO -- : [pry-remote-em] listening for connections on pryems://0.0.0.0:6464/
@@ -194,7 +194,7 @@ I, [2012-07-13T21:10:00.938835 #88528]  INFO -- : [pry-remote-em] listening for 
 I, [2012-07-13T21:10:00.939230 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:6468/
 I, [2012-07-13T21:10:00.939640 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:6469/
 I, [2012-07-13T21:10:01.031576 #88528]  INFO -- : [pry-remote-em broker] received client connection from 127.0.0.1:62288
-I, [2012-07-13T21:10:01.031931 #88528]  INFO -- : [pry-remote-em] client connected to pryem://127.0.0.1:6461/
+I, [2012-07-13T21:10:01.031931 #88528]  INFO -- : [pry-remote-em] client connected to pryem://127.0.0.1:6462/
 I, [2012-07-13T21:10:01.032120 #88528]  INFO -- : [pry-remote-em] remote is PryRemoteEm 0.7.0 pryem
 I, [2012-07-13T21:10:01.032890 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6462/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.125123 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6469/ - "#<#<Class:0x007f924b9bbee8>>"
@@ -211,7 +211,7 @@ running on a different host. Just specify the Brokers address in the
 PRYEMBROKER environment variable or the :broker_host option passed to #remote_pry_em.
 
 To connect to a broker running on a seperate host with the cli client
-just specify it on the command line ``bin/pry-remote-em preym://10.0.0.2:6461/``.
+just specify it on the command line ``bin/pry-remote-em preym://10.0.0.2:6462/``.
 You can then proxy your client connections to remote servers through
 that Broker.
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ class Foo
   end
 end
 
-EM.run { Foo.new 10, 20 } 
+EM.run { Foo.new 10, 20 }
 ```
 
 Running it will print out a message telling you Pry is waiting for a
 program to connect itself to it:
 
-     [pry-remote-em] listening for connections on pryem://localhost:6462/
+     [pry-remote-em] listening for connections on pryem://127.0.0.1:6462/
 
 You can then connect to the pry session using ``pry-remote-em``:
 
@@ -114,12 +114,12 @@ EM.run {
 $ pry-remote-em pryem://127.0.0.1:6462/
 [pry-remote-em] client connected to pryem://127.0.0.1:6462/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("pretty_print")> 
+[1] pry("pretty_print")>
 
 $ pry-remote-em  pryem://127.0.0.1:6463/
 [pry-remote-em] client connected to pryem://127.0.0.1:6463/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("pack")> 
+[1] pry("pack")>
 
 $ pry-remote-em  pryem://127.0.0.1:6464/
 [pry-remote-em] client connected to pryem://127.0.0.1:6464/
@@ -129,12 +129,12 @@ $ pry-remote-em  pryem://127.0.0.1:6464/
 $ pry-remote-em  pryem://127.0.0.1:6465/
 [pry-remote-em] client connected to pryem://127.0.0.1:6465/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("to_json")> 
+[1] pry("to_json")>
 
 $ pry-remote-em  pryem://127.0.0.1:6466/
 [pry-remote-em] client connected to pryem://127.0.0.1:6466/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry(#<RubyVM::InstructionSequence>)> 
+[1] pry(#<RubyVM::InstructionSequence>)>
 ```
 
 ## Server Broker
@@ -142,9 +142,9 @@ $ pry-remote-em  pryem://127.0.0.1:6466/
 When more than one server is running on a given host and each server is
 started with :auto it can be time consuming to manually figure out which
 port each server is running on. The Broker which listens on port 6461
-keeps track of which server is running on which port. 
+keeps track of which server is running on which port.
 
-By default the pry-remote-em cli utility will connect to the broker and 
+By default the pry-remote-em cli utility will connect to the broker and
 retrieve a list of known servers. You can then select one to connect to
 by its id, name or url. You can also choose to proxy your connection
 through the broker to the selected server.
@@ -182,7 +182,7 @@ variable, or in :broker_host option passed to #remote_pry_em.
 
 ```shell
 
-$ PRYEMBROKER=0.0.0.0 be ./test/service.rb  
+$ PRYEMBROKER=0.0.0.0 be ./test/service.rb
 I, [2012-07-13T21:10:00.936993 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:6462/
 I, [2012-07-13T21:10:00.937132 #88528]  INFO -- : [pry-remote-em broker] listening on pryem://0.0.0.0:6461
 I, [2012-07-13T21:10:00.937264 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:1337/
@@ -196,13 +196,13 @@ I, [2012-07-13T21:10:00.939640 #88528]  INFO -- : [pry-remote-em] listening for 
 I, [2012-07-13T21:10:01.031576 #88528]  INFO -- : [pry-remote-em broker] received client connection from 127.0.0.1:62288
 I, [2012-07-13T21:10:01.031931 #88528]  INFO -- : [pry-remote-em] client connected to pryem://127.0.0.1:6461/
 I, [2012-07-13T21:10:01.032120 #88528]  INFO -- : [pry-remote-em] remote is PryRemoteEm 0.7.0 pryem
-I, [2012-07-13T21:10:01.032890 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6462/ - "#<#<Class:0x007f924b9bbee8>>" 
-I, [2012-07-13T21:10:01.125123 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6469/ - "#<#<Class:0x007f924b9bbee8>>" 
+I, [2012-07-13T21:10:01.032890 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6462/ - "#<#<Class:0x007f924b9bbee8>>"
+I, [2012-07-13T21:10:01.125123 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6469/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.125487 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6467/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.490729 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6464/ - "#<#<Class:0x007f924b9bbee8>>"
-I, [2012-07-13T21:10:01.583015 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:1337/ - "#<Foo>"                       
+I, [2012-07-13T21:10:01.583015 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:1337/ - "#<Foo>"
 I, [2012-07-13T21:10:01.674842 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6466/ - "#<#<Class:0x007f924b9bbee8>>"
-I, [2012-07-13T21:10:01.766813 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6468/ - "#<#<Class:0x007f924b9bbee8>>" 
+I, [2012-07-13T21:10:01.766813 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6468/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.858423 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6465/ - "#<#<Class:0x007f924b9bbee8>>"
 ```
 
@@ -220,18 +220,18 @@ TLS enabled server.
 
 
 ## TLS Encryption
-  
-When creating a server pass the :tls => true option to enable TLS. 
+
+When creating a server pass the :tls => true option to enable TLS.
 
 ```ruby
 obj.remote_pry_em('localhost', :auto, :tls => true)
 ```
 
-If you pass a Hash it will be used to configure the internal TLS handler. 
+If you pass a Hash it will be used to configure the internal TLS handler.
 
 ```ruby
 obj.remote_pry_em('localhost', :auto, :tls => {:private_key_file => '/tmp/server.key'})
-``` 
+```
 See [EventMachine::Connection#start_tls](http://eventmachine.rubyforge.org/EventMachine/Connection.html#M000296) for the available options.
 
 
@@ -244,7 +244,7 @@ $ pry-remote-em pryem://localhost:6462/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryems
 [pry-remote-em] negotiating TLS
 [pry-remote-em] TLS connection established
-[1] pry(#<Hash>)> 
+[1] pry(#<Hash>)>
 ```
 
 To always require a TLS connection give pry-remote-em a pryem*s* URL. If
@@ -323,7 +323,7 @@ $ pry-remote-em pryems://localhost:6464/
 [pry-remote-em] TLS connection established
 user: caleb
 caleb's password: *****
-[1] pry(#<Hash>)> 
+[1] pry(#<Hash>)>
 ```
 
 
@@ -357,7 +357,7 @@ $ bin/pry-remote-em pryems:///
 [pry-remote-em] client connected to pryem://127.0.0.1:6462/
 [pry-remote-em] remote is PryRemoteEm 0.2.0 pryems
 [1] pry(#<Hash>)> key (^TAB ^TAB)
-key   key?  keys  
+key   key?  keys
 [1] pry(#<Hash>)> keys
 => [:encoding]
 ```
@@ -469,7 +469,7 @@ Copyright (c) 2012 Caleb Crane
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation 
+to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
 and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:

--- a/bin/pry-remote-em
+++ b/bin/pry-remote-em
@@ -40,7 +40,13 @@ OptionParser.new do |opts|
   opts.parse!(ARGV)
 end
 
-uri = ARGV[0] || "pryem://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"
+uri = if ARGV[0].nil? || ARGV[0].empty?
+  host = ENV['PRYEMBROKER'].nil? || ENV['PRYEMBROKER'].empty? ? PryRemoteEm::DEF_BROKERHOST : ENV['PRYEMBROKER']
+  port = ENV['PRYEMBROKERPORT'].nil? || ENV['PRYEMBROKERPORT'].empty? ? PryRemoteEm::DEF_BROKERPORT : ENV['PRYEMBROKERPORT']
+  "pryem://#{host}:#{port}"
+else
+  ARGV[0]
+end
 uri = URI.parse(uri)
 unless %w(pryem pryems).include?(uri.scheme)
   abort "only pryem URIs are currently supported\n usage: pryem[s]://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"

--- a/bin/pry-remote-em
+++ b/bin/pry-remote-em
@@ -13,6 +13,9 @@ OptionParser.new do |opts|
   opts.on("-p", "--proxy NAME", "proxy through the broker to the first pry remote em server matching NAME") do |name|
     options[:proxy] = name
   end
+  opts.on("-P", "--proxy_by_default", "show servers table with proxy mode enabled by default (ignored on -c or -p)") do |name|
+    options[:proxy_by_default] = true
+  end
 
   opts.on("--fh HOST", "--filter-host HOST", "only show servers listening at the given address (regexp)") do |host|
     if host =~ /^pryems?:\/\//

--- a/bin/pry-remote-em
+++ b/bin/pry-remote-em
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+﻿#!/usr/bin/env ruby
 
 require 'uri'
 require 'highline'
@@ -9,24 +9,24 @@ options = {}
 OptionParser.new do |opts|
   opts.on("-c", "--connect NAME", "connect to the first pry remote em server matching NAME") do |name|
     options[:connect] = name
-  end 
+  end
   opts.on("-p", "--proxy NAME", "proxy through the broker to the first pry remote em server matching NAME") do |name|
     options[:proxy] = name
-  end 
+  end
 
   opts.on("--fh HOST", "--filter-host HOST", "only show servers listening at the given address (regexp)") do |host|
     if host =~ /^pryems?:\/\//
       ARGV.push(host)
-    else  
+    else
       options[:filter_host] = Regexp.new(host)
-    end 
-  end 
+    end
+  end
   opts.on("--fn NAME", "--filter-name NAME", "only show servers with a matching name (regexp)") do |name|
     if name =~ /^pryems?:\/\//
       ARGV.push(name)
-    else  
+    else
       options[:filter_name] = Regexp.new(name)
-    end 
+    end
   end
   opts.on("--[no-]fs", "--[no-]filter-ssl", "show only servers that support ssl") do |ssl|
     options[:filter_ssl] = ssl
@@ -38,12 +38,12 @@ OptionParser.new do |opts|
   opts.on('--ss', '--sort-ssl', 'sort by ssl support') { options[:sort] = :ssl }
 
   opts.parse!(ARGV)
-end 
+end
 
-uri = ARGV[0] || "pryem://localhost:#{PryRemoteEm::DEF_BROKERPORT}"
+uri = ARGV[0] || "pryem://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"
 uri = URI.parse(uri)
 unless %w(pryem pryems).include?(uri.scheme)
-  abort "only pryem URIs are currently supported\n usage: pryem[s]://127.0.0.1:#{PryRemoteEm::DEF_BROKERPORT}" 
+  abort "only pryem URIs are currently supported\n usage: pryem[s]://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"
 end
 uri.port = PryRemoteEm::DEF_BROKERPORT unless uri.port
 
@@ -57,7 +57,7 @@ auth_proc = proc do
              HighLine.new.ask("#{user}'s password: ") { |q| q.echo = '*'}
            else
              raise "password is required to authenticate"
-           end 
+           end
   [user, pass]
 end
 

--- a/lib/pry-remote-em.rb
+++ b/lib/pry-remote-em.rb
@@ -13,7 +13,7 @@ require 'uri'
 module PryRemoteEm
   DEFHOST         = '127.0.0.1'
   DEFPORT         = 6463
-  DEF_BROKERPORT  = DEFPORT - 1
+  DEF_BROKERPORT  = 6462
   DEF_BROKERHOST  = '127.0.0.1'
   NEGOTIMER       = 15
 end

--- a/lib/pry-remote-em.rb
+++ b/lib/pry-remote-em.rb
@@ -1,4 +1,4 @@
-begin
+﻿begin
   require 'openssl'
 rescue LoadError
   warn "OpenSSL support is not available"
@@ -11,10 +11,10 @@ require 'fiber'
 require 'uri'
 
 module PryRemoteEm
-  DEFHOST         = 'localhost'
+  DEFHOST         = '127.0.0.1'
   DEFPORT         = 6463
   DEF_BROKERPORT  = DEFPORT - 1
-  DEF_BROKERHOST  = 'localhost'
+  DEF_BROKERHOST  = '127.0.0.1'
   NEGOTIMER       = 15
 end
 

--- a/lib/pry-remote-em.rb
+++ b/lib/pry-remote-em.rb
@@ -20,7 +20,9 @@ end
 
 
 class Object
-  def remote_pry_em(host = PryRemoteEm::DEFHOST, port = PryRemoteEm::DEFPORT, opts = {:tls => false}, &blk)
+  def remote_pry_em(host = nil, port = nil, opts = {:tls => false}, &blk)
+    host ||= ENV['PRYEMHOST'].nil? || ENV['PRYEMHOST'].empty? ? PryRemoteEm::DEFHOST : ENV['PRYEMHOST']
+    port ||= ENV['PRYEMPORT'].nil? || ENV['PRYEMPORT'].empty? ? PryRemoteEm::DEFPORT : ENV['PRYEMPORT']
     opts = {:target => self}.merge(opts)
     PryRemoteEm::Server.run(opts[:target], host, port, opts, &blk)
   end

--- a/lib/pry-remote-em/broker.rb
+++ b/lib/pry-remote-em/broker.rb
@@ -10,7 +10,9 @@ module PryRemoteEm
       attr_reader :listening, :host, :port
       alias :listening? :listening
 
-      def run(host = ENV['PRYEMBROKER'] || DEF_BROKERHOST, port = ENV['PRYEMBROKERPORT'] || DEF_BROKERPORT, opts = {:tls => false})
+      def run(host = nil, port = nil, opts = {:tls => false})
+        host ||= ENV['PRYEMBROKER'].nil? || ENV['PRYEMBROKER'].empty? ? DEF_BROKERHOST : ENV['PRYEMBROKER']
+        port ||= ENV['PRYEMBROKERPORT'].nil? || ENV['PRYEMBROKERPORT'].empty? ? DEF_BROKERPORT : ENV['PRYEMBROKERPORT']
         port = port.to_i if port.kind_of?(String)
         raise "root permission required for port below 1024 (#{port})" if port < 1024 && Process.euid != 0
         @host      = host

--- a/lib/pry-remote-em/broker.rb
+++ b/lib/pry-remote-em/broker.rb
@@ -1,4 +1,4 @@
-require 'socket'
+﻿require 'socket'
 require 'pry-remote-em'
 require 'pry-remote-em/client/broker'
 require 'pry-remote-em/client/proxy'
@@ -134,8 +134,8 @@ module PryRemoteEm
     end
 
     def receive_register_server(url, name)
-      url      = URI.parse(url)
-      url.host = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1'].include?(url.host)
+      url = URI.parse(url)
+      url.hostname = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1', '::1'].include?(url.hostname)
       log.info("[pry-remote-em broker] registered #{url} - #{name.inspect}") unless Broker.servers[url] == name
       Broker.servers[url] = name
       Broker.hbeats[url]  = Time.new
@@ -144,8 +144,8 @@ module PryRemoteEm
     end
 
     def receive_unregister_server(url)
-      url      = URI.parse(url)
-      url.host = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1'].include?(url.host)
+      url = URI.parse(url)
+      url.hostname = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1', '::1'].include?(url.hostname)
       log.warn("[pry-remote-em broker] unregister #{url}")
       Broker.servers.delete(url)
     end
@@ -181,6 +181,7 @@ module PryRemoteEm
       return @peer_ip if @peer_ip
       return "" if get_peername.nil?
       @peer_port, @peer_ip = Socket.unpack_sockaddr_in(get_peername)
+      @peer_ip = '127.0.0.1' if @peer_ip == '::1' # Little hack to avoid segmentation fault in EventMachine 1.2.0.1 while connecting to PryRemoteEm Server from localhost with IPv6 address
       @peer_ip
     end
 

--- a/lib/pry-remote-em/broker.rb
+++ b/lib/pry-remote-em/broker.rb
@@ -194,7 +194,7 @@ module PryRemoteEm
     def peer_port
       return @peer_port if @peer_port
       return "" if get_peername.nil?
-      @peer_port, @peer_ip = Socket.unpack_sockaddr_in(get_peername)
+      peer_ip # Fills peer_port too
       @peer_port
     end
 

--- a/lib/pry-remote-em/client.rb
+++ b/lib/pry-remote-em/client.rb
@@ -94,7 +94,6 @@ module PryRemoteEm
 
     def choose_server(list)
       highline    = HighLine.new
-      proxy       = false
       choice      = nil
       nm_col_len  = list.values.map(&:length).sort[-1] + 5
       ur_col_len  = list.keys.map(&:length).sort[-1] + 5
@@ -110,18 +109,25 @@ module PryRemoteEm
       table << border
       table   = table.join("\n")
       Kernel.puts table
+
+      proxy = if (choice = opts.delete(:proxy))
+        true
+      elsif (choice = opts.delete(:connect))
+        false
+      elsif opts.delete(:proxy_by_default)
+        true
+      else
+        false
+      end
+
       while choice.nil?
         if proxy
-          question = "(q) to quit; (r) to refresh (c) to connect\nproxy to: "
+          question = "(q) to quit; (r) to refresh (c) to connect without proxy\nproxy to: "
         else
           question = "(q) to quit; (r) to refresh (p) to proxy\nconnect to: "
         end
-        if (choice = opts.delete(:proxy))
-          proxy = true
-        else
-          choice = opts.delete(:connect) || highline.ask(question)
-          proxy = false
-        end
+
+        choice = highline.ask(question)
 
         return close_connection if ['q', 'quit', 'exit'].include?(choice.downcase)
         if ['r', 'reload', 'refresh'].include?(choice.downcase)

--- a/lib/pry-remote-em/client.rb
+++ b/lib/pry-remote-em/client.rb
@@ -209,11 +209,14 @@ module PryRemoteEm
     # TODO detect if the old pager behavior of Pry is supported and use it
     # through Pry.pager. If it's not then use the SimplePager.
     def pager
-      @pager ||= Pry::Pager::SimplePager.new($stdout)
+      pager_class = ENV['PRYEMNOPAGER'] ? Pry::Pager::NullPager : @opts[:pager] || Pry::Pager::SimplePager
+      @pager ||= pager_class.new(Pry::Output.new(Pry))
     end
 
     def receive_raw(r)
       pager.write(r)
+    rescue Pry::Pager::StopPaging
+      warn "[pry-remote-em] stop paging is not implemented, use PRYEMNOPAGER environment variable to avoid paging at all"
     end
 
     def receive_unknown(j)

--- a/lib/pry-remote-em/server.rb
+++ b/lib/pry-remote-em/server.rb
@@ -74,7 +74,9 @@ module PryRemoteEm
       # @option opts [Logger] :logger
       # @option opts [Proc, Object] :auth require user authentication - see README
       # @option opts [Boolean] :allow_shell_cmds
-      def run(obj, host = ENV['PRYEMHOST'] || DEFHOST, port = ENV['PRYEMPORT'] || DEFPORT, opts = {:tls => false})
+      def run(obj, host = nil, port = nil, opts = {:tls => false})
+        host ||= ENV['PRYEMHOST'].nil? || ENV['PRYEMHOST'].empty? ? DEFHOST : ENV['PRYEMHOST']
+        port ||= ENV['PRYEMPORT'].nil? || ENV['PRYEMPORT'].empty? ? DEFPORT : ENV['PRYEMPORT']
         port = :auto if port == 'auto'
         port = port.to_i if port.kind_of?(String)
         tries = [port, opts[:port_fail]].include?(:auto) ? 100 : 1

--- a/lib/pry-remote-em/server.rb
+++ b/lib/pry-remote-em/server.rb
@@ -103,13 +103,12 @@ module PryRemoteEm
           end
           raise "can't bind to #{host}:#{port} - #{e}"
         end
-        url    = "#{opts[:tls] ? 'pryems' : 'pryem'}://#{host}:#{port}/"
-        name   = opts[:name] || ENV['PRYEMNAME']
-        name ||= obj.send(:eval, 'self') rescue "#{obj}"
-        name   = Pry.view_clip(name)
+        url  = opts[:external_url] || ENV['PRYEMURL'] || "#{opts[:tls] ? 'pryems' : 'pryem'}://#{host}:#{port}/"
+        name = opts[:name] || ENV['PRYEMNAME'] || obj.send(:eval, 'self') rescue "#{obj}"
+        name = Pry.view_clip(name)
         PryRemoteEm.servers[url] = [server, name]
         (opts[:logger] || ::Logger.new(STDERR)).info("[pry-remote-em] listening for connections on #{url}")
-        Broker.run(opts[:broker_host] || ENV['PRYEMBROKER'] || DEF_BROKERHOST, opts[:broker_port] || ENV['PRYEMBROKERPORT'] || DEF_BROKERPORT, opts) do |broker|
+        Broker.run(opts[:broker_host], opts[:broker_port], opts) do |broker|
           broker.register(url, name)
           rereg = EM::PeriodicTimer.new(15) do
             EM.get_sockname(server) ? broker.register(url, name) : nil #rereg.cancel


### PR DESCRIPTION
* Fix proxy, it didn't work at all
* Fix IPv6 localhost problem (details here: https://github.com/simulacre/pry-remote-em/pull/49)
* Fix `libc++abi.dylib: Pure virtual function called!` error on client disconnecting
* Fix console crash on pager quit
* Fix missing requires when using broker without server
* Fix port access check when using environment variables
* Add more environment variables to control server without code changing
* Add support for empty environment variables and nil arguments on server start
* Add ability to use custom server name
* Add possibility to set external url for server to use lib with NAT or Docker
* Add ability to start server without starting broker
* Add proxy-by-default setting to CLI
* Correct README for default broker port